### PR TITLE
Fix packaging to enable uv tool install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,12 @@ dependencies = [
     "uvicorn>=0.30.0",
     "starlette>=0.37.0",
 ]
+
+[project.scripts]
+junos-mcp-server = "jmcp:main"
+
+[tool.setuptools]
+py-modules = ["jmcp", "jmcp_token_manager"]
+
+[tool.setuptools.packages.find]
+include = ["utils*"]


### PR DESCRIPTION
## Summary

This PR fixes two packaging issues that prevent installation via `uv tool install`:

### Issue 1: Missing console script entry point
The `pyproject.toml` was missing a `[project.scripts]` section, so `uv tool install` didn't know what command to create.

**Fix:** Added `[project.scripts]` with entry point: `junos-mcp-server = "jmcp:main"`

### Issue 2: Broken flat-layout package structure
Setuptools was failing with:
```
error: Multiple top-level modules discovered in a flat-layout: ['test_junos_cli', 'test_config_validation', 'jmcp', 'test_get_router_list', 'jmcp_token_manager', 'test_batch_command'].
```

**Fix:** Added `[tool.setuptools]` configuration to explicitly specify:
- `py-modules`: `jmcp` and `jmcp_token_manager`
- `packages.find`: `utils` package
- This excludes test files from the package

## Testing

✅ Package builds successfully with `uv build`
✅ Package installs successfully with `uv tool install .`
✅ Command `junos-mcp-server --help` works correctly

## Result

Users can now install the package via:
```bash
uv tool install git+https://github.com/Juniper/junos-mcp-server
```