### PR TITLE
feat: thread-safe SSH/NETCONF connection pooling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,25 +32,31 @@ docker run --rm -it -v /path/to/devices.json:/app/config/devices.json -p 30030:3
 
 ### Testing and Development
 
-- No automated tests are currently configured
-- No linting configuration is present
-- Manual testing requires a valid Junos device configuration in JSON format
+- Run the unit tests with `make test` (or `python -m unittest discover -s tests -v`)
+- Code style is enforced with Black (configured in `pyproject.toml`); check with `black --check .` and auto-format with `black .`. CI runs Black and the unit tests (`.github/workflows/ci.yml`).
+- Live testing against devices requires a valid Junos device configuration in JSON format
 
 ## Architecture
 
-The server implements six MCP tools in `jmcp.py`:
+The server implements 11 MCP tools in `jmcp.py`:
 
 1. **execute_junos_command** - Execute arbitrary CLI commands on routers
-2. **get_junos_config** - Retrieve device configuration (uses `show configuration | display inheritance no-comments`)
-3. **junos_config_diff** - Compare configuration versions (rollback comparison)
-4. **gather_device_facts** - Collect device information using PyEZ facts
-5. **get_router_list** - List available routers from the configuration
-6. **load_and_commit_config** - Apply configuration changes (supports set/text/xml formats)
+2. **execute_junos_command_batch** - Execute the same command on multiple routers in parallel
+3. **execute_junos_pfe_command** - Execute a PFE (packet forwarding engine) command on an FPC
+4. **get_junos_config** - Retrieve device configuration (uses `show configuration | display inheritance no-comments`)
+5. **junos_config_diff** - Compare configuration versions (rollback comparison)
+6. **render_and_apply_j2_template** - Render a Jinja2 template and load/commit it
+7. **gather_device_facts** - Collect device information using PyEZ facts
+8. **get_router_list** - List available routers from the configuration
+9. **load_and_commit_config** - Apply configuration changes (supports set/text/xml formats)
+10. **add_device** - Add a device to the in-memory mapping at runtime
+11. **reload_devices** - Reload the device mapping from a new JSON file
 
 ### Key Implementation Details
 
-- All device connections use the `_run_junos_cli_command` helper function (jmcp.py:81)
-- Connection parameters are prepared by `prepare_connection_params` (jmcp.py:42) which handles both password and SSH key authentication
+- Device connections are pooled and reused across tool calls via the thread-safe `ConnectionPool` (`connection_pool.get_connection`); helpers such as `_run_junos_cli_command` borrow from it. PyEZ's blocking calls are dispatched off the async event loop with `anyio.to_thread.run_sync`.
+- Idle pooled connections are closed after `JMCP_POOL_IDLE_TIMEOUT` seconds (default 300)
+- Connection parameters are prepared by `prepare_connection_params` which handles both password and SSH key authentication
 - Default timeout is 360 seconds for long-running operations
 - The server uses FastMCP for the MCP protocol implementation
 - Device configurations are loaded from a JSON file at startup
@@ -85,7 +91,7 @@ The device configuration file must follow this structure:
 
 When modifying the server:
 
-1. **Adding new tools**: Follow the existing pattern using `@mcp.tool()` decorator
+1. **Adding new tools**: Register the handler in the `TOOL_HANDLERS` dict and declare its schema in `list_tools()`. A single `@app.call_tool()` dispatcher routes calls by name — there are no per-tool `@mcp.tool()` decorators, so a handler that isn't in `TOOL_HANDLERS` is never invoked.
 2. **Error handling**: Use try/except blocks around device operations to catch ConnectError and general exceptions
 3. **Authentication**: Any changes must support both password and SSH key authentication types
 4. **Logging**: Use the global `log` logger for debugging (`logging.getLogger('jmcp-server')`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ The server implements 11 MCP tools in `jmcp.py`:
 
 ### Key Implementation Details
 
-- Device connections are pooled and reused across tool calls via the thread-safe `ConnectionPool` (`connection_pool.get_connection`); helpers such as `_run_junos_cli_command` borrow from it. PyEZ's blocking calls are dispatched off the async event loop with `anyio.to_thread.run_sync`.
+- Most device-accessing handlers borrow from the thread-safe `ConnectionPool` (`connection_pool.get_connection`) and dispatch PyEZ's blocking calls off the async event loop with `anyio.to_thread.run_sync` (e.g. `execute_junos_command`/`_batch`, `get_junos_config`, `gather_device_facts`, `load_and_commit_config`). Two paths intentionally do not: `render_and_apply_j2_template` opens a direct, non-pooled session and runs inline (pooling it is deferred to a follow-up), and the `add_device` connectivity check makes a one-off probe of a not-yet-registered device.
 - Idle pooled connections are closed after `JMCP_POOL_IDLE_TIMEOUT` seconds (default 300)
 - Connection parameters are prepared by `prepare_connection_params` which handles both password and SSH key authentication
 - Default timeout is 360 seconds for long-running operations

--- a/jmcp.py
+++ b/jmcp.py
@@ -94,8 +94,17 @@ class ConnectionPool:
         self._connections: dict[str, dict] = {}
         self._pool_lock = threading.Lock()
         if idle_timeout is None:
+            self._idle_timeout = 300
             env_val = os.getenv("JMCP_POOL_IDLE_TIMEOUT")
-            self._idle_timeout = int(env_val) if env_val else 300
+            if env_val is not None:
+                try:
+                    self._idle_timeout = int(env_val)
+                except ValueError:
+                    log.warning(
+                        "Invalid JMCP_POOL_IDLE_TIMEOUT environment variable "
+                        "value: %s. Using default idle timeout.",
+                        env_val,
+                    )
         else:
             self._idle_timeout = idle_timeout
         self._running = True

--- a/jmcp.py
+++ b/jmcp.py
@@ -26,7 +26,9 @@ import os
 import re
 import signal
 import sys
+import threading
 import time
+from contextlib import contextmanager
 from collections.abc import Iterable
 from datetime import datetime, timezone
 from pathlib import Path
@@ -78,6 +80,162 @@ devices = {}
 
 # Junos MCP Server
 JUNOS_MCP = "jmcp-server"
+
+
+class ConnectionPool:
+    """Thread-safe SSH connection pool for Junos devices.
+
+    Reuses SSH sessions across tool calls instead of opening a new connection
+    for every command. Idle connections are closed after a configurable timeout
+    (default 300s, configurable via JMCP_POOL_IDLE_TIMEOUT env var).
+    """
+
+    def __init__(self, idle_timeout: int = None):
+        self._connections: dict[str, dict] = {}
+        self._pool_lock = threading.Lock()
+        if idle_timeout is None:
+            env_val = os.getenv("JMCP_POOL_IDLE_TIMEOUT")
+            self._idle_timeout = int(env_val) if env_val else 300
+        else:
+            self._idle_timeout = idle_timeout
+        self._running = True
+        self._cleanup_thread = threading.Thread(
+            target=self._cleanup_loop, daemon=True, name="pool-cleanup"
+        )
+        self._cleanup_thread.start()
+        log.info(
+            "Connection pool initialized (idle_timeout=%ds)", self._idle_timeout
+        )
+
+    @contextmanager
+    def get_connection(self, router_name: str, timeout: int = 360):
+        """Get a pooled device connection. Creates or reuses as needed.
+
+        Args:
+            router_name: Name of the router (must exist in devices dict)
+            timeout: Command timeout to set on the device
+
+        Yields:
+            An open jnpr.junos.Device instance
+
+        Raises:
+            ValueError: If connection params are invalid
+            ConnectError: If SSH connection fails
+        """
+        entry = self._get_or_create_entry(router_name)
+        entry["lock"].acquire()
+        try:
+            device = entry["device"]
+            if device is None or not device.connected:
+                if device is not None:
+                    try:
+                        device.close()
+                    except Exception:
+                        pass
+                    entry["device"] = None
+                device_info = devices[router_name]
+                connect_params = prepare_connection_params(device_info, router_name)
+                device = Device(**connect_params)
+                device.open()
+                entry["device"] = device
+                log.info("Pool: opened new connection to %s", router_name)
+            else:
+                log.debug("Pool: reusing connection to %s", router_name)
+
+            device.timeout = timeout
+            yield device
+            entry["last_used"] = time.time()
+        except Exception:
+            # Invalidate connection if it's no longer alive
+            if entry["device"] is not None and not entry["device"].connected:
+                try:
+                    entry["device"].close()
+                except Exception:
+                    pass
+                entry["device"] = None
+            raise
+        finally:
+            entry["lock"].release()
+
+    def _get_or_create_entry(self, router_name: str) -> dict:
+        with self._pool_lock:
+            if router_name not in self._connections:
+                self._connections[router_name] = {
+                    "device": None,
+                    "lock": threading.Lock(),
+                    "last_used": 0.0,
+                }
+            return self._connections[router_name]
+
+    def _cleanup_loop(self):
+        while self._running:
+            time.sleep(60)
+            self._cleanup_idle()
+
+    def _cleanup_idle(self):
+        now = time.time()
+        with self._pool_lock:
+            for router_name in list(self._connections):
+                entry = self._connections[router_name]
+                if entry["lock"].locked():
+                    continue
+                if (
+                    entry["device"] is not None
+                    and entry["last_used"] > 0
+                    and (now - entry["last_used"]) > self._idle_timeout
+                ):
+                    if entry["lock"].acquire(blocking=False):
+                        try:
+                            try:
+                                entry["device"].close()
+                            except Exception as e:
+                                log.debug(
+                                    "Pool: error closing idle connection to %s: %s",
+                                    router_name,
+                                    e,
+                                )
+                            entry["device"] = None
+                            log.info(
+                                "Pool: closed idle connection to %s (idle %.0fs)",
+                                router_name,
+                                now - entry["last_used"],
+                            )
+                        finally:
+                            entry["lock"].release()
+
+    def close_all(self):
+        """Close all pooled connections."""
+        self._running = False
+        with self._pool_lock:
+            for router_name, entry in self._connections.items():
+                if entry["device"] is not None:
+                    try:
+                        entry["device"].close()
+                    except Exception as e:
+                        log.debug(
+                            "Pool: error closing connection to %s: %s",
+                            router_name,
+                            e,
+                        )
+                    entry["device"] = None
+            self._connections.clear()
+        log.info("Connection pool: all connections closed")
+
+    @property
+    def stats(self) -> dict:
+        """Return pool statistics."""
+        with self._pool_lock:
+            total = len(self._connections)
+            active = sum(
+                1
+                for e in self._connections.values()
+                if e["device"] is not None and e["device"].connected
+            )
+            return {"total_entries": total, "active_connections": active}
+
+
+# Global connection pool instance
+connection_pool = ConnectionPool()
 
 
 class Context(BaseModel, Generic[ServerSessionT, LifespanContextT, RequestT]):
@@ -648,23 +806,19 @@ The device is now available for use with all Junos MCP tools."""
 
 
 def _run_junos_cli_command(router_name: str, command: str, timeout: int = 360) -> str:
-    """Internal helper to connect and run a Junos CLI command."""
+    """Internal helper to run a Junos CLI command using the connection pool."""
     log.debug(
         "Executing command %s on router %s with timeout %ss (internal)",
         command,
         router_name,
         timeout,
     )
-    device_info = devices[router_name]
     try:
-        connect_params = prepare_connection_params(device_info, router_name)
-    except ValueError as ve:
-        return f"Error: {ve}"
-    try:
-        with Device(**connect_params) as junos_device:
-            junos_device.timeout = timeout
+        with connection_pool.get_connection(router_name, timeout) as junos_device:
             op = junos_device.cli(command, warning=False)
             return op
+    except ValueError as ve:
+        return f"Error: {ve}"
     except ConnectError as ce:
         return f"Connection error to {router_name}: {ce}"
     except Exception as e:
@@ -686,17 +840,13 @@ def _run_junos_pfe_command(
         router_name,
         timeout,
     )
-    device_info = devices[router_name]
     try:
-        connect_params = prepare_connection_params(device_info, router_name)
-    except ValueError as ve:
-        return f"Error: {ve}"
-    try:
-        with Device(**connect_params) as junos_device:
-            junos_device.timeout = timeout
+        with connection_pool.get_connection(router_name, timeout) as junos_device:
             op = junos_device.rpc.request_pfe_execute(target=target, command=command)
             result_text = op.text if hasattr(op, "text") else str(op)
             return {target: result_text}
+    except ValueError as ve:
+        return f"Error: {ve}"
     except ConnectError as ce:
         return f"Connection error to {router_name}: {ce}"
     except Exception as e:
@@ -1470,161 +1620,133 @@ router_name or router_names.
                 f"{'Checking' if dry_run else 'Applying'} configuration on {rtr_name}..."
             )
 
-            device_info = devices[rtr_name]
-
-            # Use prepare_connection_params to get proper connection parameters
-            try:
-                connect_params = prepare_connection_params(device_info, rtr_name)
-            except ValueError as ve:
-                application_results.append(f"❌ {rtr_name}: {ve}")
-                await context.error(f"{rtr_name}: {ve}")
-                continue
-
-            # Connect to device
-            dev = Device(**connect_params)
-
-            try:
-                dev.open()
+            with connection_pool.get_connection(rtr_name) as dev:
                 await context.info(f"Connected to {rtr_name}")
 
                 # Load configuration using exclusive mode
-                try:
-                    with Config(dev, mode="exclusive") as cu:
-                        await context.info(f"Loading configuration on {rtr_name}...")
-                        cu.load(rendered_config, format="set")
+                with Config(dev, mode="exclusive") as cu:
+                    await context.info(f"Loading configuration on {rtr_name}...")
+                    cu.load(rendered_config, format="set")
 
-                        # Get diff
-                        diff = cu.diff()
+                    # Get diff
+                    diff = cu.diff()
 
-                        if not diff:
-                            result_msg = "No configuration changes detected"
-                            application_results.append(f"ℹ️  {rtr_name}: {result_msg}")
-                            await context.info(f"{rtr_name}: {result_msg}")
-                        else:
-                            if dry_run:
-                                # DRY RUN: Perform commit check, show diff,
-                                # and rollback without committing
-                                await context.info(
-                                    f"Performing commit check on {rtr_name}..."
-                                )
+                    if not diff:
+                        result_msg = "No configuration changes detected"
+                        application_results.append(f"ℹ️  {rtr_name}: {result_msg}")
+                        await context.info(f"{rtr_name}: {result_msg}")
+                    else:
+                        if dry_run:
+                            # DRY RUN: Perform commit check, show diff,
+                            # and rollback without committing
+                            await context.info(
+                                f"Performing commit check on {rtr_name}..."
+                            )
 
-                                try:
-                                    check_result = cu.commit_check()
-
-                                    if not check_result:
-                                        result_msg = (
-                                            "Commit check failed - "
-                                            "configuration has errors"
-                                        )
-                                        application_results.append(
-                                            f"❌ {rtr_name}: {result_msg}"
-                                        )
-                                        await context.error(f"{rtr_name}: {result_msg}")
-                                    else:
-                                        result_msg = (
-                                            "Configuration check successful. "
-                                            f"Changes:\n\n{diff}"
-                                        )
-                                        application_results.append(
-                                            f"🔍 {rtr_name}: {result_msg}"
-                                        )
-                                        await context.info(
-                                            f"{rtr_name}: Dry-run commit check passed"
-                                        )
-
-                                except Exception as check_error:
-                                    result_msg = f"Commit check error: {check_error}"
-                                    application_results.append(
-                                        f"❌ {rtr_name}: {result_msg}"
-                                    )
-                                    await context.error(f"{rtr_name}: {result_msg}")
-                                finally:
-                                    # CRITICAL: Always rollback in dry-run mode
-                                    await context.info(
-                                        f"{rtr_name}: Rolling back changes (dry-run mode)"
-                                    )
-                                    try:
-                                        # Perform the rollback
-                                        cu.rollback()
-                                        # Verify rollback success by checking
-                                        # if there are pending changes.
-                                        # After a successful rollback, there
-                                        # should be no differences.
-                                        diff = cu.diff()
-
-                                        if diff:
-                                            await context.error(
-                                                f"{rtr_name}: Rollback verification "
-                                                "failed - unexpected changes remain"
-                                            )
-                                            await context.error(
-                                                f"{rtr_name}: Remaining diff:\n{diff}"
-                                            )
-                                        else:
-                                            await context.info(
-                                                f"{rtr_name}: Rollback verified "
-                                                "successfully - no pending changes"
-                                            )
-
-                                    except Exception as rollback_error:
-                                        await context.error(
-                                            f"{rtr_name}: Rollback failed with "
-                                            f"error: {str(rollback_error)}"
-                                        )
-                            else:
-                                # REAL COMMIT: Perform commit check before committing
-                                await context.info(
-                                    f"Performing commit check on {rtr_name}..."
-                                )
+                            try:
                                 check_result = cu.commit_check()
 
                                 if not check_result:
                                     result_msg = (
-                                        "Commit check failed - configuration has errors"
+                                        "Commit check failed - "
+                                        "configuration has errors"
                                     )
                                     application_results.append(
                                         f"❌ {rtr_name}: {result_msg}"
                                     )
                                     await context.error(f"{rtr_name}: {result_msg}")
-                                    cu.rollback()
                                 else:
-                                    # Apply the changes
-                                    await context.info(
-                                        f"Committing configuration on {rtr_name}..."
-                                    )
-                                    cu.commit(comment=commit_comment)
                                     result_msg = (
-                                        "Configuration committed successfully. "
+                                        "Configuration check successful. "
                                         f"Changes:\n\n{diff}"
                                     )
                                     application_results.append(
-                                        f"✅ {rtr_name}: {result_msg}"
+                                        f"🔍 {rtr_name}: {result_msg}"
                                     )
                                     await context.info(
-                                        f"{rtr_name}: Configuration committed successfully"
+                                        f"{rtr_name}: Dry-run commit check passed"
                                     )
 
-                except (ConfigLoadError, CommitError, LockError) as e:
-                    error_msg = f"Configuration error: {e}"
-                    application_results.append(f"❌ {rtr_name}: {error_msg}")
-                    await context.error(f"{rtr_name}: {error_msg}")
+                            except Exception as check_error:
+                                result_msg = f"Commit check error: {check_error}"
+                                application_results.append(
+                                    f"❌ {rtr_name}: {result_msg}"
+                                )
+                                await context.error(f"{rtr_name}: {result_msg}")
+                            finally:
+                                # CRITICAL: Always rollback in dry-run mode
+                                await context.info(
+                                    f"{rtr_name}: Rolling back changes (dry-run mode)"
+                                )
+                                try:
+                                    # Perform the rollback
+                                    cu.rollback()
+                                    # Verify rollback success by checking
+                                    # if there are pending changes.
+                                    # After a successful rollback, there
+                                    # should be no differences.
+                                    diff = cu.diff()
 
-            except ConnectError as e:
-                error_msg = f"Connection failed: {e}"
-                application_results.append(f"❌ {rtr_name}: {error_msg}")
-                await context.error(f"{rtr_name}: {error_msg}")
-            finally:
-                # Always close the device connection
-                try:
-                    dev.close()
-                    await context.info(f"Disconnected from {rtr_name}")
-                except Exception as close_error:
-                    log.warning(
-                        "Error while closing test connection to %s: %s",
-                        rtr_name,
-                        close_error,
-                    )
+                                    if diff:
+                                        await context.error(
+                                            f"{rtr_name}: Rollback verification "
+                                            "failed - unexpected changes remain"
+                                        )
+                                        await context.error(
+                                            f"{rtr_name}: Remaining diff:\n{diff}"
+                                        )
+                                    else:
+                                        await context.info(
+                                            f"{rtr_name}: Rollback verified "
+                                            "successfully - no pending changes"
+                                        )
 
+                                except Exception as rollback_error:
+                                    await context.error(
+                                        f"{rtr_name}: Rollback failed with "
+                                        f"error: {str(rollback_error)}"
+                                    )
+                        else:
+                            # REAL COMMIT: Perform commit check before committing
+                            await context.info(
+                                f"Performing commit check on {rtr_name}..."
+                            )
+                            check_result = cu.commit_check()
+
+                            if not check_result:
+                                result_msg = (
+                                    "Commit check failed - configuration has errors"
+                                )
+                                application_results.append(
+                                    f"❌ {rtr_name}: {result_msg}"
+                                )
+                                await context.error(f"{rtr_name}: {result_msg}")
+                                cu.rollback()
+                            else:
+                                # Apply the changes
+                                await context.info(
+                                    f"Committing configuration on {rtr_name}..."
+                                )
+                                cu.commit(comment=commit_comment)
+                                result_msg = (
+                                    "Configuration committed successfully. "
+                                    f"Changes:\n\n{diff}"
+                                )
+                                application_results.append(
+                                    f"✅ {rtr_name}: {result_msg}"
+                                )
+                                await context.info(
+                                    f"{rtr_name}: Configuration committed successfully"
+                                )
+
+        except (ValueError, ConnectError) as e:
+            error_msg = f"Connection failed: {e}"
+            application_results.append(f"❌ {rtr_name}: {error_msg}")
+            await context.error(f"{rtr_name}: {error_msg}")
+        except (ConfigLoadError, CommitError, LockError) as e:
+            error_msg = f"Configuration error: {e}"
+            application_results.append(f"❌ {rtr_name}: {error_msg}")
+            await context.error(f"{rtr_name}: {error_msg}")
         except Exception as e:
             error_msg = f"Failed to apply configuration: {e}"
             application_results.append(f"❌ {rtr_name}: {error_msg}")
@@ -1673,33 +1795,29 @@ async def handle_gather_device_facts(
         result = f"Router {router_name} not found in the device mapping."
     else:
         log.debug("Getting facts from router %s with timeout %ss", router_name, timeout)
-        device_info = devices[router_name]
         try:
-            connect_params = prepare_connection_params(device_info, router_name)
-            connect_params["timeout"] = timeout
+            with connection_pool.get_connection(router_name, timeout) as junos_device:
+                junos_device.facts_refresh()
+                facts = junos_device.facts
+                # Convert _FactCache to a regular dict
+                facts_dict = dict(facts)
+
+                # Custom JSON encoder to handle version_info and other complex objects
+                def json_serializer(obj):
+                    if hasattr(obj, "_asdict"):  # Named tuples like version_info
+                        return obj._asdict()
+                    elif hasattr(obj, "__dict__"):  # Objects with __dict__
+                        return obj.__dict__
+                    else:
+                        return str(obj)
+
+                result = json.dumps(facts_dict, indent=2, default=json_serializer)
         except ValueError as ve:
             result = f"Error: {ve}"
-        else:
-            try:
-                with Device(**connect_params) as junos_device:
-                    facts = junos_device.facts
-                    # Convert _FactCache to a regular dict
-                    facts_dict = dict(facts)
-
-                    # Custom JSON encoder to handle version_info and other complex objects
-                    def json_serializer(obj):
-                        if hasattr(obj, "_asdict"):  # Named tuples like version_info
-                            return obj._asdict()
-                        elif hasattr(obj, "__dict__"):  # Objects with __dict__
-                            return obj.__dict__
-                        else:
-                            return str(obj)
-
-                    result = json.dumps(facts_dict, indent=2, default=json_serializer)
-            except ConnectError as ce:
-                result = f"Connection error to {router_name}: {ce}"
-            except Exception as e:
-                result = f"An error occurred: {e}"
+        except ConnectError as ce:
+            result = f"Connection error to {router_name}: {ce}"
+        except Exception as e:
+            result = f"An error occurred: {e}"
 
     content_block = types.TextContent(
         type="text", text=result, annotations={"router_name": router_name}
@@ -1741,6 +1859,9 @@ async def handle_reload_devices(
                 type="text", text=f"Error: Device configuration validation failed: {e}"
             )
         ]
+
+    # Close all pooled connections since device configs may have changed
+    connection_pool.close_all()
 
     old_count = len(devices)
     devices = new_devices
@@ -1886,76 +2007,71 @@ async def handle_load_and_commit_config(
             router_name,
             config_format,
         )
-        device_info = devices[router_name]
-
         try:
-            connect_params = prepare_connection_params(device_info, router_name)
-        except ValueError as ve:
-            result = f"Error: {ve}"
-        else:
-            try:
-                with Device(**connect_params) as junos_device:
-                    # Initialize configuration utility
-                    config_util = Config(junos_device)
+            with connection_pool.get_connection(router_name, timeout) as junos_device:
+                # Initialize configuration utility
+                config_util = Config(junos_device)
 
-                    # Lock the configuration
+                # Lock the configuration
+                try:
+                    config_util.lock()
+                except Exception as e:
+                    result = f"Failed to lock configuration: {e}"
+                else:
                     try:
-                        config_util.lock()
-                    except Exception as e:
-                        result = f"Failed to lock configuration: {e}"
-                    else:
-                        try:
-                            # Load the configuration based on format
-                            if config_format.lower() == "set":
-                                config_util.load(config_text, format="set")
-                            elif config_format.lower() == "text":
-                                config_util.load(config_text, format="text")
-                            elif config_format.lower() == "xml":
-                                config_util.load(config_text, format="xml")
+                        # Load the configuration based on format
+                        if config_format.lower() == "set":
+                            config_util.load(config_text, format="set")
+                        elif config_format.lower() == "text":
+                            config_util.load(config_text, format="text")
+                        elif config_format.lower() == "xml":
+                            config_util.load(config_text, format="xml")
+                        else:
+                            config_util.unlock()
+                            result = (
+                                f"Error: Unsupported config format "
+                                f"'{config_format}'. Use 'set', 'text', or 'xml'"
+                            )
+
+                        if "result" not in locals():
+                            # Check for differences
+                            diff = config_util.diff()
+                            if not diff:
+                                config_util.unlock()
+                                result = "No configuration changes detected"
                             else:
+                                # Commit the configuration
+                                config_util.commit(
+                                    comment=commit_comment, timeout=timeout
+                                )
                                 config_util.unlock()
                                 result = (
-                                    f"Error: Unsupported config format "
-                                    f"'{config_format}'. Use 'set', 'text', or 'xml'"
+                                    "Configuration successfully loaded and "
+                                    f"committed on {router_name}. Changes:\n{diff}"
                                 )
 
-                            if "result" not in locals():
-                                # Check for differences
-                                diff = config_util.diff()
-                                if not diff:
-                                    config_util.unlock()
-                                    result = "No configuration changes detected"
-                                else:
-                                    # Commit the configuration
-                                    config_util.commit(
-                                        comment=commit_comment, timeout=timeout
-                                    )
-                                    config_util.unlock()
-                                    result = (
-                                        "Configuration successfully loaded and "
-                                        f"committed on {router_name}. Changes:\n{diff}"
-                                    )
+                    except Exception as e:
+                        # If anything fails, rollback and unlock
+                        try:
+                            config_util.rollback()
+                            config_util.unlock()
+                        except (
+                            ConfigLoadError,
+                            CommitError,
+                            LockError,
+                            RuntimeError,
+                            OSError,
+                            AttributeError,
+                        ):
+                            pass
+                        result = f"Failed to load/commit configuration: {e}"
 
-                        except Exception as e:
-                            # If anything fails, rollback and unlock
-                            try:
-                                config_util.rollback()
-                                config_util.unlock()
-                            except (
-                                ConfigLoadError,
-                                CommitError,
-                                LockError,
-                                RuntimeError,
-                                OSError,
-                                AttributeError,
-                            ):
-                                pass
-                            result = f"Failed to load/commit configuration: {e}"
-
-            except ConnectError as ce:
-                result = f"Connection error to {router_name}: {ce}"
-            except Exception as e:
-                result = f"An error occurred: {e}"
+        except ValueError as ve:
+            result = f"Error: {ve}"
+        except ConnectError as ce:
+            result = f"Connection error to {router_name}: {ce}"
+        except Exception as e:
+            result = f"An error occurred: {e}"
 
     content_block = types.TextContent(
         type="text",
@@ -2400,6 +2516,7 @@ def main():
     # Set up signal handler for clean shutdown
     def signal_handler(sig, frame):
         print("\nShutting down MCP server...")
+        connection_pool.close_all()
         sys.exit(0)
 
     signal.signal(signal.SIGINT, signal_handler)

--- a/jmcp.py
+++ b/jmcp.py
@@ -1160,7 +1160,9 @@ async def handle_execute_junos_command(
             router_name,
             timeout,
         )
-        result = _run_junos_cli_command(router_name, command, timeout)
+        result = await anyio.to_thread.run_sync(
+            _run_junos_cli_command, router_name, command, timeout
+        )
 
     end_time = time.time()
     end_timestamp = datetime.now(timezone.utc).isoformat()
@@ -1804,23 +1806,24 @@ async def handle_gather_device_facts(
         result = f"Router {router_name} not found in the device mapping."
     else:
         log.debug("Getting facts from router %s with timeout %ss", router_name, timeout)
-        try:
+
+        def _gather_facts_sync() -> str:
             with connection_pool.get_connection(router_name, timeout) as junos_device:
                 junos_device.facts_refresh()
-                facts = junos_device.facts
-                # Convert _FactCache to a regular dict
-                facts_dict = dict(facts)
+                facts_dict = dict(junos_device.facts)
 
-                # Custom JSON encoder to handle version_info and other complex objects
                 def json_serializer(obj):
-                    if hasattr(obj, "_asdict"):  # Named tuples like version_info
+                    if hasattr(obj, "_asdict"):
                         return obj._asdict()
-                    elif hasattr(obj, "__dict__"):  # Objects with __dict__
+                    elif hasattr(obj, "__dict__"):
                         return obj.__dict__
                     else:
                         return str(obj)
 
-                result = json.dumps(facts_dict, indent=2, default=json_serializer)
+                return json.dumps(facts_dict, indent=2, default=json_serializer)
+
+        try:
+            result = await anyio.to_thread.run_sync(_gather_facts_sync)
         except ValueError as ve:
             result = f"Error: {ve}"
         except ConnectError as ce:
@@ -1957,8 +1960,8 @@ async def handle_execute_pfe_command(
             router_name,
             timeout,
         )
-        result = _run_junos_pfe_command(
-            router_name, target=target, command=command, timeout=timeout
+        result = await anyio.to_thread.run_sync(
+            _run_junos_pfe_command, router_name, target, command, timeout
         )
         if isinstance(result, dict):
             # Normal case: RPC succeeded, result is a dict keyed by target
@@ -2016,65 +2019,54 @@ async def handle_load_and_commit_config(
             router_name,
             config_format,
         )
-        try:
-            with connection_pool.get_connection(router_name, timeout) as junos_device:
-                # Initialize configuration utility
-                config_util = Config(junos_device)
 
-                # Lock the configuration
+        def _load_and_commit_sync() -> str:
+            with connection_pool.get_connection(router_name, timeout) as junos_device:
+                config_util = Config(junos_device)
                 try:
                     config_util.lock()
                 except Exception as e:
-                    result = f"Failed to lock configuration: {e}"
-                else:
+                    return f"Failed to lock configuration: {e}"
+
+                try:
+                    fmt = config_format.lower()
+                    if fmt in ("set", "text", "xml"):
+                        config_util.load(config_text, format=fmt)
+                    else:
+                        config_util.unlock()
+                        return (
+                            f"Error: Unsupported config format "
+                            f"'{config_format}'. Use 'set', 'text', or 'xml'"
+                        )
+
+                    diff = config_util.diff()
+                    if not diff:
+                        config_util.unlock()
+                        return "No configuration changes detected"
+
+                    config_util.commit(comment=commit_comment, timeout=timeout)
+                    config_util.unlock()
+                    return (
+                        "Configuration successfully loaded and "
+                        f"committed on {router_name}. Changes:\n{diff}"
+                    )
+                except Exception as e:
                     try:
-                        # Load the configuration based on format
-                        if config_format.lower() == "set":
-                            config_util.load(config_text, format="set")
-                        elif config_format.lower() == "text":
-                            config_util.load(config_text, format="text")
-                        elif config_format.lower() == "xml":
-                            config_util.load(config_text, format="xml")
-                        else:
-                            config_util.unlock()
-                            result = (
-                                f"Error: Unsupported config format "
-                                f"'{config_format}'. Use 'set', 'text', or 'xml'"
-                            )
+                        config_util.rollback()
+                        config_util.unlock()
+                    except (
+                        ConfigLoadError,
+                        CommitError,
+                        LockError,
+                        RuntimeError,
+                        OSError,
+                        AttributeError,
+                    ):
+                        pass
+                    return f"Failed to load/commit configuration: {e}"
 
-                        if "result" not in locals():
-                            # Check for differences
-                            diff = config_util.diff()
-                            if not diff:
-                                config_util.unlock()
-                                result = "No configuration changes detected"
-                            else:
-                                # Commit the configuration
-                                config_util.commit(
-                                    comment=commit_comment, timeout=timeout
-                                )
-                                config_util.unlock()
-                                result = (
-                                    "Configuration successfully loaded and "
-                                    f"committed on {router_name}. Changes:\n{diff}"
-                                )
-
-                    except Exception as e:
-                        # If anything fails, rollback and unlock
-                        try:
-                            config_util.rollback()
-                            config_util.unlock()
-                        except (
-                            ConfigLoadError,
-                            CommitError,
-                            LockError,
-                            RuntimeError,
-                            OSError,
-                            AttributeError,
-                        ):
-                            pass
-                        result = f"Failed to load/commit configuration: {e}"
-
+        try:
+            result = await anyio.to_thread.run_sync(_load_and_commit_sync)
         except ValueError as ve:
             result = f"Error: {ve}"
         except ConnectError as ce:

--- a/jmcp.py
+++ b/jmcp.py
@@ -212,9 +212,18 @@ class ConnectionPool:
                         finally:
                             entry["lock"].release()
 
-    def close_all(self):
-        """Close all pooled connections."""
-        self._running = False
+    def close_all(self, shutdown: bool = True):
+        """Close all pooled connections.
+
+        Args:
+            shutdown: If True (default), also stop the idle-cleanup thread —
+                use on server shutdown. If False, drop all connections but
+                keep the pool operational (cleanup thread keeps running) —
+                use on device reload, where configs changed but the pool
+                must keep serving.
+        """
+        if shutdown:
+            self._running = False
         with self._pool_lock:
             for router_name, entry in self._connections.items():
                 if entry["device"] is not None:
@@ -1903,8 +1912,10 @@ async def handle_reload_devices(
             )
         ]
 
-    # Close all pooled connections since device configs may have changed
-    connection_pool.close_all()
+    # Drop pooled connections since device configs may have changed, but keep
+    # the pool (and its idle-cleanup thread) alive. Run in a worker thread so
+    # the blocking device.close() calls don't stall the async event loop.
+    await anyio.to_thread.run_sync(connection_pool.close_all, False)
 
     old_count = len(devices)
     devices = new_devices

--- a/jmcp.py
+++ b/jmcp.py
@@ -26,7 +26,9 @@ import os
 import re
 import signal
 import sys
+import threading
 import time
+from contextlib import contextmanager
 from collections.abc import Iterable
 from datetime import datetime, timezone
 from pathlib import Path
@@ -78,6 +80,162 @@ devices = {}
 
 # Junos MCP Server
 JUNOS_MCP = "jmcp-server"
+
+
+class ConnectionPool:
+    """Thread-safe SSH connection pool for Junos devices.
+
+    Reuses SSH sessions across tool calls instead of opening a new connection
+    for every command. Idle connections are closed after a configurable timeout
+    (default 300s, configurable via JMCP_POOL_IDLE_TIMEOUT env var).
+    """
+
+    def __init__(self, idle_timeout: int = None):
+        self._connections: dict[str, dict] = {}
+        self._pool_lock = threading.Lock()
+        if idle_timeout is None:
+            env_val = os.getenv("JMCP_POOL_IDLE_TIMEOUT")
+            self._idle_timeout = int(env_val) if env_val else 300
+        else:
+            self._idle_timeout = idle_timeout
+        self._running = True
+        self._cleanup_thread = threading.Thread(
+            target=self._cleanup_loop, daemon=True, name="pool-cleanup"
+        )
+        self._cleanup_thread.start()
+        log.info(
+            "Connection pool initialized (idle_timeout=%ds)", self._idle_timeout
+        )
+
+    @contextmanager
+    def get_connection(self, router_name: str, timeout: int = 360):
+        """Get a pooled device connection. Creates or reuses as needed.
+
+        Args:
+            router_name: Name of the router (must exist in devices dict)
+            timeout: Command timeout to set on the device
+
+        Yields:
+            An open jnpr.junos.Device instance
+
+        Raises:
+            ValueError: If connection params are invalid
+            ConnectError: If SSH connection fails
+        """
+        entry = self._get_or_create_entry(router_name)
+        entry["lock"].acquire()
+        try:
+            device = entry["device"]
+            if device is None or not device.connected:
+                if device is not None:
+                    try:
+                        device.close()
+                    except Exception:
+                        pass
+                    entry["device"] = None
+                device_info = devices[router_name]
+                connect_params = prepare_connection_params(device_info, router_name)
+                device = Device(**connect_params)
+                device.open()
+                entry["device"] = device
+                log.info("Pool: opened new connection to %s", router_name)
+            else:
+                log.debug("Pool: reusing connection to %s", router_name)
+
+            device.timeout = timeout
+            yield device
+            entry["last_used"] = time.time()
+        except Exception:
+            # Invalidate connection if it's no longer alive
+            if entry["device"] is not None and not entry["device"].connected:
+                try:
+                    entry["device"].close()
+                except Exception:
+                    pass
+                entry["device"] = None
+            raise
+        finally:
+            entry["lock"].release()
+
+    def _get_or_create_entry(self, router_name: str) -> dict:
+        with self._pool_lock:
+            if router_name not in self._connections:
+                self._connections[router_name] = {
+                    "device": None,
+                    "lock": threading.Lock(),
+                    "last_used": 0.0,
+                }
+            return self._connections[router_name]
+
+    def _cleanup_loop(self):
+        while self._running:
+            time.sleep(60)
+            self._cleanup_idle()
+
+    def _cleanup_idle(self):
+        now = time.time()
+        with self._pool_lock:
+            for router_name in list(self._connections):
+                entry = self._connections[router_name]
+                if entry["lock"].locked():
+                    continue
+                if (
+                    entry["device"] is not None
+                    and entry["last_used"] > 0
+                    and (now - entry["last_used"]) > self._idle_timeout
+                ):
+                    if entry["lock"].acquire(blocking=False):
+                        try:
+                            try:
+                                entry["device"].close()
+                            except Exception as e:
+                                log.debug(
+                                    "Pool: error closing idle connection to %s: %s",
+                                    router_name,
+                                    e,
+                                )
+                            entry["device"] = None
+                            log.info(
+                                "Pool: closed idle connection to %s (idle %.0fs)",
+                                router_name,
+                                now - entry["last_used"],
+                            )
+                        finally:
+                            entry["lock"].release()
+
+    def close_all(self):
+        """Close all pooled connections."""
+        self._running = False
+        with self._pool_lock:
+            for router_name, entry in self._connections.items():
+                if entry["device"] is not None:
+                    try:
+                        entry["device"].close()
+                    except Exception as e:
+                        log.debug(
+                            "Pool: error closing connection to %s: %s",
+                            router_name,
+                            e,
+                        )
+                    entry["device"] = None
+            self._connections.clear()
+        log.info("Connection pool: all connections closed")
+
+    @property
+    def stats(self) -> dict:
+        """Return pool statistics."""
+        with self._pool_lock:
+            total = len(self._connections)
+            active = sum(
+                1
+                for e in self._connections.values()
+                if e["device"] is not None and e["device"].connected
+            )
+            return {"total_entries": total, "active_connections": active}
+
+
+# Global connection pool instance
+connection_pool = ConnectionPool()
 
 
 class Context(BaseModel, Generic[ServerSessionT, LifespanContextT, RequestT]):
@@ -648,23 +806,19 @@ The device is now available for use with all Junos MCP tools."""
 
 
 def _run_junos_cli_command(router_name: str, command: str, timeout: int = 360) -> str:
-    """Internal helper to connect and run a Junos CLI command."""
+    """Internal helper to run a Junos CLI command using the connection pool."""
     log.debug(
         "Executing command %s on router %s with timeout %ss (internal)",
         command,
         router_name,
         timeout,
     )
-    device_info = devices[router_name]
     try:
-        connect_params = prepare_connection_params(device_info, router_name)
-    except ValueError as ve:
-        return f"Error: {ve}"
-    try:
-        with Device(**connect_params) as junos_device:
-            junos_device.timeout = timeout
+        with connection_pool.get_connection(router_name, timeout) as junos_device:
             op = junos_device.cli(command, warning=False)
             return op
+    except ValueError as ve:
+        return f"Error: {ve}"
     except ConnectError as ce:
         return f"Connection error to {router_name}: {ce}"
     except Exception as e:
@@ -686,17 +840,13 @@ def _run_junos_pfe_command(
         router_name,
         timeout,
     )
-    device_info = devices[router_name]
     try:
-        connect_params = prepare_connection_params(device_info, router_name)
-    except ValueError as ve:
-        return f"Error: {ve}"
-    try:
-        with Device(**connect_params) as junos_device:
-            junos_device.timeout = timeout
+        with connection_pool.get_connection(router_name, timeout) as junos_device:
             op = junos_device.rpc.request_pfe_execute(target=target, command=command)
             result_text = op.text if hasattr(op, "text") else str(op)
             return {target: result_text}
+    except ValueError as ve:
+        return f"Error: {ve}"
     except ConnectError as ce:
         return f"Connection error to {router_name}: {ce}"
     except Exception as e:
@@ -1676,33 +1826,29 @@ async def handle_gather_device_facts(
         result = f"Router {router_name} not found in the device mapping."
     else:
         log.debug("Getting facts from router %s with timeout %ss", router_name, timeout)
-        device_info = devices[router_name]
         try:
-            connect_params = prepare_connection_params(device_info, router_name)
-            connect_params["timeout"] = timeout
+            with connection_pool.get_connection(router_name, timeout) as junos_device:
+                junos_device.facts_refresh()
+                facts = junos_device.facts
+                # Convert _FactCache to a regular dict
+                facts_dict = dict(facts)
+
+                # Custom JSON encoder to handle version_info and other complex objects
+                def json_serializer(obj):
+                    if hasattr(obj, "_asdict"):  # Named tuples like version_info
+                        return obj._asdict()
+                    elif hasattr(obj, "__dict__"):  # Objects with __dict__
+                        return obj.__dict__
+                    else:
+                        return str(obj)
+
+                result = json.dumps(facts_dict, indent=2, default=json_serializer)
         except ValueError as ve:
             result = f"Error: {ve}"
-        else:
-            try:
-                with Device(**connect_params) as junos_device:
-                    facts = junos_device.facts
-                    # Convert _FactCache to a regular dict
-                    facts_dict = dict(facts)
-
-                    # Custom JSON encoder to handle version_info and other complex objects
-                    def json_serializer(obj):
-                        if hasattr(obj, "_asdict"):  # Named tuples like version_info
-                            return obj._asdict()
-                        elif hasattr(obj, "__dict__"):  # Objects with __dict__
-                            return obj.__dict__
-                        else:
-                            return str(obj)
-
-                    result = json.dumps(facts_dict, indent=2, default=json_serializer)
-            except ConnectError as ce:
-                result = f"Connection error to {router_name}: {ce}"
-            except Exception as e:
-                result = f"An error occurred: {e}"
+        except ConnectError as ce:
+            result = f"Connection error to {router_name}: {ce}"
+        except Exception as e:
+            result = f"An error occurred: {e}"
 
     content_block = types.TextContent(
         type="text", text=result, annotations={"router_name": router_name}
@@ -1744,6 +1890,9 @@ async def handle_reload_devices(
                 type="text", text=f"Error: Device configuration validation failed: {e}"
             )
         ]
+
+    # Close all pooled connections since device configs may have changed
+    connection_pool.close_all()
 
     old_count = len(devices)
     devices = new_devices
@@ -1889,76 +2038,71 @@ async def handle_load_and_commit_config(
             router_name,
             config_format,
         )
-        device_info = devices[router_name]
-
         try:
-            connect_params = prepare_connection_params(device_info, router_name)
-        except ValueError as ve:
-            result = f"Error: {ve}"
-        else:
-            try:
-                with Device(**connect_params) as junos_device:
-                    # Initialize configuration utility
-                    config_util = Config(junos_device)
+            with connection_pool.get_connection(router_name, timeout) as junos_device:
+                # Initialize configuration utility
+                config_util = Config(junos_device)
 
-                    # Lock the configuration
+                # Lock the configuration
+                try:
+                    config_util.lock()
+                except Exception as e:
+                    result = f"Failed to lock configuration: {e}"
+                else:
                     try:
-                        config_util.lock()
-                    except Exception as e:
-                        result = f"Failed to lock configuration: {e}"
-                    else:
-                        try:
-                            # Load the configuration based on format
-                            if config_format.lower() == "set":
-                                config_util.load(config_text, format="set")
-                            elif config_format.lower() == "text":
-                                config_util.load(config_text, format="text")
-                            elif config_format.lower() == "xml":
-                                config_util.load(config_text, format="xml")
+                        # Load the configuration based on format
+                        if config_format.lower() == "set":
+                            config_util.load(config_text, format="set")
+                        elif config_format.lower() == "text":
+                            config_util.load(config_text, format="text")
+                        elif config_format.lower() == "xml":
+                            config_util.load(config_text, format="xml")
+                        else:
+                            config_util.unlock()
+                            result = (
+                                f"Error: Unsupported config format "
+                                f"'{config_format}'. Use 'set', 'text', or 'xml'"
+                            )
+
+                        if "result" not in locals():
+                            # Check for differences
+                            diff = config_util.diff()
+                            if not diff:
+                                config_util.unlock()
+                                result = "No configuration changes detected"
                             else:
+                                # Commit the configuration
+                                config_util.commit(
+                                    comment=commit_comment, timeout=timeout
+                                )
                                 config_util.unlock()
                                 result = (
-                                    f"Error: Unsupported config format "
-                                    f"'{config_format}'. Use 'set', 'text', or 'xml'"
+                                    "Configuration successfully loaded and "
+                                    f"committed on {router_name}. Changes:\n{diff}"
                                 )
 
-                            if "result" not in locals():
-                                # Check for differences
-                                diff = config_util.diff()
-                                if not diff:
-                                    config_util.unlock()
-                                    result = "No configuration changes detected"
-                                else:
-                                    # Commit the configuration
-                                    config_util.commit(
-                                        comment=commit_comment, timeout=timeout
-                                    )
-                                    config_util.unlock()
-                                    result = (
-                                        "Configuration successfully loaded and "
-                                        f"committed on {router_name}. Changes:\n{diff}"
-                                    )
+                    except Exception as e:
+                        # If anything fails, rollback and unlock
+                        try:
+                            config_util.rollback()
+                            config_util.unlock()
+                        except (
+                            ConfigLoadError,
+                            CommitError,
+                            LockError,
+                            RuntimeError,
+                            OSError,
+                            AttributeError,
+                        ):
+                            pass
+                        result = f"Failed to load/commit configuration: {e}"
 
-                        except Exception as e:
-                            # If anything fails, rollback and unlock
-                            try:
-                                config_util.rollback()
-                                config_util.unlock()
-                            except (
-                                ConfigLoadError,
-                                CommitError,
-                                LockError,
-                                RuntimeError,
-                                OSError,
-                                AttributeError,
-                            ):
-                                pass
-                            result = f"Failed to load/commit configuration: {e}"
-
-            except ConnectError as ce:
-                result = f"Connection error to {router_name}: {ce}"
-            except Exception as e:
-                result = f"An error occurred: {e}"
+        except ValueError as ve:
+            result = f"Error: {ve}"
+        except ConnectError as ce:
+            result = f"Connection error to {router_name}: {ce}"
+        except Exception as e:
+            result = f"An error occurred: {e}"
 
     content_block = types.TextContent(
         type="text",
@@ -2495,6 +2639,7 @@ def main():
     # Set up signal handler for clean shutdown
     def signal_handler(sig, frame):
         print("\nShutting down MCP server...")
+        connection_pool.close_all()
         sys.exit(0)
 
     signal.signal(signal.SIGINT, signal_handler)

--- a/jmcp.py
+++ b/jmcp.py
@@ -153,7 +153,6 @@ class ConnectionPool:
 
             device.timeout = timeout
             yield device
-            entry["last_used"] = time.time()
         except Exception:
             # Invalidate connection if it's no longer alive
             if entry["device"] is not None and not entry["device"].connected:
@@ -164,6 +163,11 @@ class ConnectionPool:
                 entry["device"] = None
             raise
         finally:
+            # Refresh last_used on every borrow — success OR failure. Otherwise a
+            # connection whose operation raised while still connected keeps
+            # last_used at 0.0, and the idle-cleanup loop (which requires
+            # last_used > 0) would never reap it.
+            entry["last_used"] = time.time()
             entry["lock"].release()
 
     def _get_or_create_entry(self, router_name: str) -> dict:
@@ -1922,14 +1926,20 @@ async def handle_reload_devices(
             )
         ]
 
-    # Drop pooled connections since device configs may have changed, but keep
-    # the pool (and its idle-cleanup thread) alive. Run in a worker thread so
-    # the blocking device.close() calls don't stall the async event loop.
-    await anyio.to_thread.run_sync(connection_pool.close_all, False)
-
     old_count = len(devices)
+    # Swap the device map FIRST, then drop the old pooled connections. Order
+    # matters: connection_pool.get_connection() reads `devices` only after
+    # creating its pool entry, and entry creation is serialized with
+    # close_all()'s snapshot via the pool's global lock. So any connection a
+    # concurrent tool call opens during the reset is guaranteed to use the NEW
+    # config — no old-config connection can slip past the close. close_all keeps
+    # the pool (and idle-cleanup thread) alive and waits for in-flight ops via
+    # the per-router lock; run it in a worker thread so its blocking
+    # device.close() calls don't stall the async event loop.
     devices = new_devices
     new_count = len(devices)
+
+    await anyio.to_thread.run_sync(connection_pool.close_all, False)
 
     log.info(
         "Reloaded devices from '%s': %s -> %s device(s)",
@@ -2106,19 +2116,16 @@ async def handle_load_and_commit_config(
                     try:
                         config_util.rollback()
                         config_util.unlock()
-                    except (
-                        ConfigLoadError,
-                        CommitError,
-                        LockError,
-                        RuntimeError,
-                        OSError,
-                        AttributeError,
-                    ):
-                        # Rollback/unlock failed: this session may still hold the
-                        # config lock. Drop the transport so the pool evicts it
-                        # (via the `not device.connected` check in get_connection)
-                        # on next use, instead of returning a locked session that
-                        # fails every later commit with "database is locked".
+                    except Exception:
+                        # Cleanup failed for ANY reason (e.g. unlock() raising
+                        # UnlockError, or rollback() a bare RpcError — neither a
+                        # subclass of the previously-allowlisted types): this
+                        # session may still hold the config lock. Drop the
+                        # transport so the pool evicts it (via the
+                        # `not device.connected` check in get_connection) instead
+                        # of returning a locked session that fails every later
+                        # commit with "database is locked". Classifying the
+                        # failure is the outer `except Exception as e`'s job.
                         try:
                             junos_device.close()
                         except Exception:

--- a/jmcp.py
+++ b/jmcp.py
@@ -224,8 +224,16 @@ class ConnectionPool:
         """
         if shutdown:
             self._running = False
+        # Detach all entries under the global lock, then close each under its
+        # own per-router lock (outside the global lock). Acquiring entry["lock"]
+        # makes us wait for any in-flight operation to finish instead of closing
+        # a live transport mid-RPC, and avoids holding the global lock — which
+        # would block unrelated routers — for the whole close loop.
         with self._pool_lock:
-            for router_name, entry in self._connections.items():
+            entries = list(self._connections.items())
+            self._connections.clear()
+        for router_name, entry in entries:
+            with entry["lock"]:
                 if entry["device"] is not None:
                     try:
                         entry["device"].close()
@@ -2104,7 +2112,15 @@ async def handle_load_and_commit_config(
                         OSError,
                         AttributeError,
                     ):
-                        pass
+                        # Rollback/unlock failed: this session may still hold the
+                        # config lock. Drop the transport so the pool evicts it
+                        # (via the `not device.connected` check in get_connection)
+                        # on next use, instead of returning a locked session that
+                        # fails every later commit with "database is locked".
+                        try:
+                            junos_device.close()
+                        except Exception:
+                            pass
                     return f"Failed to load/commit configuration: {e}"
 
         try:

--- a/jmcp.py
+++ b/jmcp.py
@@ -112,9 +112,7 @@ class ConnectionPool:
             target=self._cleanup_loop, daemon=True, name="pool-cleanup"
         )
         self._cleanup_thread.start()
-        log.info(
-            "Connection pool initialized (idle_timeout=%ds)", self._idle_timeout
-        )
+        log.info("Connection pool initialized (idle_timeout=%ds)", self._idle_timeout)
 
     @contextmanager
     def get_connection(self, router_name: str, timeout: int = 360):

--- a/jmcp.py
+++ b/jmcp.py
@@ -1160,7 +1160,9 @@ async def handle_execute_junos_command(
             router_name,
             timeout,
         )
-        result = _run_junos_cli_command(router_name, command, timeout)
+        result = await anyio.to_thread.run_sync(
+            _run_junos_cli_command, router_name, command, timeout
+        )
 
     end_time = time.time()
     end_timestamp = datetime.now(timezone.utc).isoformat()
@@ -1835,23 +1837,24 @@ async def handle_gather_device_facts(
         result = f"Router {router_name} not found in the device mapping."
     else:
         log.debug("Getting facts from router %s with timeout %ss", router_name, timeout)
-        try:
+
+        def _gather_facts_sync() -> str:
             with connection_pool.get_connection(router_name, timeout) as junos_device:
                 junos_device.facts_refresh()
-                facts = junos_device.facts
-                # Convert _FactCache to a regular dict
-                facts_dict = dict(facts)
+                facts_dict = dict(junos_device.facts)
 
-                # Custom JSON encoder to handle version_info and other complex objects
                 def json_serializer(obj):
-                    if hasattr(obj, "_asdict"):  # Named tuples like version_info
+                    if hasattr(obj, "_asdict"):
                         return obj._asdict()
-                    elif hasattr(obj, "__dict__"):  # Objects with __dict__
+                    elif hasattr(obj, "__dict__"):
                         return obj.__dict__
                     else:
                         return str(obj)
 
-                result = json.dumps(facts_dict, indent=2, default=json_serializer)
+                return json.dumps(facts_dict, indent=2, default=json_serializer)
+
+        try:
+            result = await anyio.to_thread.run_sync(_gather_facts_sync)
         except ValueError as ve:
             result = f"Error: {ve}"
         except ConnectError as ce:
@@ -1988,8 +1991,8 @@ async def handle_execute_pfe_command(
             router_name,
             timeout,
         )
-        result = _run_junos_pfe_command(
-            router_name, target=target, command=command, timeout=timeout
+        result = await anyio.to_thread.run_sync(
+            _run_junos_pfe_command, router_name, target, command, timeout
         )
         if isinstance(result, dict):
             # Normal case: RPC succeeded, result is a dict keyed by target
@@ -2047,65 +2050,54 @@ async def handle_load_and_commit_config(
             router_name,
             config_format,
         )
-        try:
-            with connection_pool.get_connection(router_name, timeout) as junos_device:
-                # Initialize configuration utility
-                config_util = Config(junos_device)
 
-                # Lock the configuration
+        def _load_and_commit_sync() -> str:
+            with connection_pool.get_connection(router_name, timeout) as junos_device:
+                config_util = Config(junos_device)
                 try:
                     config_util.lock()
                 except Exception as e:
-                    result = f"Failed to lock configuration: {e}"
-                else:
+                    return f"Failed to lock configuration: {e}"
+
+                try:
+                    fmt = config_format.lower()
+                    if fmt in ("set", "text", "xml"):
+                        config_util.load(config_text, format=fmt)
+                    else:
+                        config_util.unlock()
+                        return (
+                            f"Error: Unsupported config format "
+                            f"'{config_format}'. Use 'set', 'text', or 'xml'"
+                        )
+
+                    diff = config_util.diff()
+                    if not diff:
+                        config_util.unlock()
+                        return "No configuration changes detected"
+
+                    config_util.commit(comment=commit_comment, timeout=timeout)
+                    config_util.unlock()
+                    return (
+                        "Configuration successfully loaded and "
+                        f"committed on {router_name}. Changes:\n{diff}"
+                    )
+                except Exception as e:
                     try:
-                        # Load the configuration based on format
-                        if config_format.lower() == "set":
-                            config_util.load(config_text, format="set")
-                        elif config_format.lower() == "text":
-                            config_util.load(config_text, format="text")
-                        elif config_format.lower() == "xml":
-                            config_util.load(config_text, format="xml")
-                        else:
-                            config_util.unlock()
-                            result = (
-                                f"Error: Unsupported config format "
-                                f"'{config_format}'. Use 'set', 'text', or 'xml'"
-                            )
+                        config_util.rollback()
+                        config_util.unlock()
+                    except (
+                        ConfigLoadError,
+                        CommitError,
+                        LockError,
+                        RuntimeError,
+                        OSError,
+                        AttributeError,
+                    ):
+                        pass
+                    return f"Failed to load/commit configuration: {e}"
 
-                        if "result" not in locals():
-                            # Check for differences
-                            diff = config_util.diff()
-                            if not diff:
-                                config_util.unlock()
-                                result = "No configuration changes detected"
-                            else:
-                                # Commit the configuration
-                                config_util.commit(
-                                    comment=commit_comment, timeout=timeout
-                                )
-                                config_util.unlock()
-                                result = (
-                                    "Configuration successfully loaded and "
-                                    f"committed on {router_name}. Changes:\n{diff}"
-                                )
-
-                    except Exception as e:
-                        # If anything fails, rollback and unlock
-                        try:
-                            config_util.rollback()
-                            config_util.unlock()
-                        except (
-                            ConfigLoadError,
-                            CommitError,
-                            LockError,
-                            RuntimeError,
-                            OSError,
-                            AttributeError,
-                        ):
-                            pass
-                        result = f"Failed to load/commit configuration: {e}"
-
+        try:
+            result = await anyio.to_thread.run_sync(_load_and_commit_sync)
         except ValueError as ve:
             result = f"Error: {ve}"
         except ConnectError as ce:

--- a/jmcp.py
+++ b/jmcp.py
@@ -244,7 +244,6 @@ class ConnectionPool:
                             e,
                         )
                     entry["device"] = None
-            self._connections.clear()
         log.info("Connection pool: all connections closed")
 
     @property
@@ -1462,7 +1461,8 @@ async def handle_get_junos_config(
         result = f"Router {router_name} not found in the device mapping."
     else:
         log.debug("Getting configuration from router %s", router_name)
-        result = _run_junos_cli_command(
+        result = await anyio.to_thread.run_sync(
+            _run_junos_cli_command,
             router_name,
             "show configuration | display inheritance no-comments | display set | no-more",
         )
@@ -1490,8 +1490,10 @@ async def handle_junos_config_diff(
             router_name,
             version,
         )
-        result = _run_junos_cli_command(
-            router_name, f"show configuration | compare rollback {version}"
+        result = await anyio.to_thread.run_sync(
+            _run_junos_cli_command,
+            router_name,
+            f"show configuration | compare rollback {version}",
         )
 
     content_block = types.TextContent(

--- a/jmcp.py
+++ b/jmcp.py
@@ -134,6 +134,13 @@ class ConnectionPool:
         Raises:
             ValueError: If connection params are invalid
             ConnectError: If SSH connection fails
+
+        Note:
+            Handlers reach the pool via anyio.to_thread.run_sync, which shares
+            anyio's process-wide default thread limiter (40 tokens). A batch
+            over >40 routers, or 40+ concurrent same-router calls, will queue at
+            that ceiling; the per-router lock below also serializes same-router
+            work.
         """
         entry = self._get_or_create_entry(router_name)
         entry["lock"].acquire()
@@ -1965,15 +1972,15 @@ async def handle_reload_devices(
         ]
 
     old_count = len(devices)
-    # Swap the device map FIRST, then drop the old pooled connections. Order
-    # matters: connection_pool.get_connection() reads `devices` only after
-    # creating its pool entry, and entry creation is serialized with
-    # close_all()'s snapshot via the pool's global lock. So any connection a
-    # concurrent tool call opens during the reset is guaranteed to use the NEW
-    # config — no old-config connection can slip past the close. close_all keeps
-    # the pool (and idle-cleanup thread) alive and waits for in-flight ops via
-    # the per-router lock; run it in a worker thread so its blocking
-    # device.close() calls don't stall the async event loop.
+    # Swap the device map FIRST, then drop the old pooled connections. close_all
+    # snapshots entries under the pool's global lock and closes each once its
+    # per-router lock frees, so no old-config connection is leaked past the
+    # reset. (A borrow already in flight may still complete one op on the
+    # previous config, and a router dropped mid-reload can raise KeyError from
+    # devices[...], which is caught and returned as an error string, not a
+    # crash.) Run close_all in a worker thread so its blocking device.close()
+    # calls don't stall the event loop; it keeps the pool and cleanup thread
+    # alive.
     devices = new_devices
     new_count = len(devices)
 

--- a/jmcp.py
+++ b/jmcp.py
@@ -39,7 +39,13 @@ import mcp.types as types
 import yaml
 from jinja2 import Environment, TemplateError
 from jnpr.junos import Device
-from jnpr.junos.exception import ConnectError, ConfigLoadError, CommitError, LockError
+from jnpr.junos.exception import (
+    ConnectError,
+    ConfigLoadError,
+    CommitError,
+    LockError,
+    RpcTimeoutError,
+)
 from jnpr.junos.utils.config import Config
 from mcp.server.elicitation import (
     AcceptedElicitation,
@@ -90,7 +96,7 @@ class ConnectionPool:
     (default 300s, configurable via JMCP_POOL_IDLE_TIMEOUT env var).
     """
 
-    def __init__(self, idle_timeout: int = None):
+    def __init__(self, idle_timeout: int | None = None):
         self._connections: dict[str, dict] = {}
         self._pool_lock = threading.Lock()
         if idle_timeout is None:
@@ -143,7 +149,18 @@ class ConnectionPool:
                 device_info = devices[router_name]
                 connect_params = prepare_connection_params(device_info, router_name)
                 device = Device(**connect_params)
-                device.open()
+                try:
+                    device.open()
+                except Exception:
+                    # open() may have partially established the transport before
+                    # raising; close the local device so we don't leak it (it was
+                    # never stored in entry["device"], so the except block below
+                    # would not see it).
+                    try:
+                        device.close()
+                    except Exception:
+                        pass
+                    raise
                 entry["device"] = device
                 log.info("Pool: opened new connection to %s", router_name)
             else:
@@ -151,11 +168,18 @@ class ConnectionPool:
 
             device.timeout = timeout
             yield device
-        except Exception:
-            # Invalidate connection if it's no longer alive
-            if entry["device"] is not None and not entry["device"].connected:
+        except Exception as exc:
+            # Invalidate the pooled connection if it is no longer usable: either
+            # the transport dropped (not connected), or an RPC timed out.
+            # RpcTimeoutError leaves device.connected True but the session is no
+            # longer reliable; pre-pooling, every call opened a fresh session so
+            # a timeout never poisoned later calls — evict to preserve that.
+            dev = entry["device"]
+            if dev is not None and (
+                not dev.connected or isinstance(exc, RpcTimeoutError)
+            ):
                 try:
-                    entry["device"].close()
+                    dev.close()
                 except Exception:
                     pass
                 entry["device"] = None
@@ -185,34 +209,47 @@ class ConnectionPool:
 
     def _cleanup_idle(self):
         now = time.time()
+        # Collect idle candidates under the global lock, then close OUTSIDE it.
+        # Holding _pool_lock across a blocking device.close() (a black-holed
+        # device can stall on TCP/SSH timeout) would freeze every router's
+        # borrow, since get_connection() needs the same lock. Mirrors close_all.
+        candidates = []
         with self._pool_lock:
-            for router_name in list(self._connections):
-                entry = self._connections[router_name]
-                if entry["lock"].locked():
-                    continue
+            for router_name, entry in self._connections.items():
                 if (
                     entry["device"] is not None
                     and entry["last_used"] > 0
                     and (now - entry["last_used"]) > self._idle_timeout
                 ):
-                    if entry["lock"].acquire(blocking=False):
-                        try:
-                            try:
-                                entry["device"].close()
-                            except Exception as e:
-                                log.debug(
-                                    "Pool: error closing idle connection to %s: %s",
-                                    router_name,
-                                    e,
-                                )
-                            entry["device"] = None
-                            log.info(
-                                "Pool: closed idle connection to %s (idle %.0fs)",
-                                router_name,
-                                now - entry["last_used"],
-                            )
-                        finally:
-                            entry["lock"].release()
+                    candidates.append((router_name, entry))
+        for router_name, entry in candidates:
+            # Non-blocking: skip entries currently in use this cycle.
+            if not entry["lock"].acquire(blocking=False):
+                continue
+            try:
+                # Re-check under the lock: the entry may have been used or closed
+                # between collection and acquiring the lock.
+                if (
+                    entry["device"] is not None
+                    and entry["last_used"] > 0
+                    and (now - entry["last_used"]) > self._idle_timeout
+                ):
+                    try:
+                        entry["device"].close()
+                    except Exception as e:
+                        log.debug(
+                            "Pool: error closing idle connection to %s: %s",
+                            router_name,
+                            e,
+                        )
+                    entry["device"] = None
+                    log.info(
+                        "Pool: closed idle connection to %s (idle %.0fs)",
+                        router_name,
+                        now - entry["last_used"],
+                    )
+            finally:
+                entry["lock"].release()
 
     def close_all(self, shutdown: bool = True):
         """Close all pooled connections.
@@ -226,16 +263,26 @@ class ConnectionPool:
         """
         if shutdown:
             self._running = False
-        # Detach all entries under the global lock, then close each under its
-        # own per-router lock (outside the global lock). Acquiring entry["lock"]
-        # makes us wait for any in-flight operation to finish instead of closing
-        # a live transport mid-RPC, and avoids holding the global lock — which
-        # would block unrelated routers — for the whole close loop.
+        # Snapshot entries under the global lock, then close each under its own
+        # per-router lock (outside the global lock, so a slow close can't block
+        # unrelated routers). Do NOT clear _connections: clearing would detach an
+        # entry that an in-flight get_connection() borrow already holds, leaving
+        # the connection it is about to open untracked and never reaped. Leaving
+        # device=None entries behind is cheap and keeps every connection
+        # reapable.
         with self._pool_lock:
             entries = list(self._connections.items())
-            self._connections.clear()
         for router_name, entry in entries:
-            with entry["lock"]:
+            if shutdown:
+                # Shutdown: don't wait on an in-flight op (the process is exiting
+                # and the OS reclaims sockets) — skip busy entries so SIGTERM
+                # during a long command doesn't hang teardown.
+                if not entry["lock"].acquire(blocking=False):
+                    continue
+            else:
+                # Reload: wait for in-flight ops so we don't sever a live RPC.
+                entry["lock"].acquire()
+            try:
                 if entry["device"] is not None:
                     try:
                         entry["device"].close()
@@ -246,19 +293,9 @@ class ConnectionPool:
                             e,
                         )
                     entry["device"] = None
+            finally:
+                entry["lock"].release()
         log.info("Connection pool: all connections closed")
-
-    @property
-    def stats(self) -> dict:
-        """Return pool statistics."""
-        with self._pool_lock:
-            total = len(self._connections)
-            active = sum(
-                1
-                for e in self._connections.values()
-                if e["device"] is not None and e["device"].connected
-            )
-            return {"total_entries": total, "active_connections": active}
 
 
 # Global connection pool instance
@@ -1230,7 +1267,10 @@ async def handle_execute_junos_command_batch(
     import asyncio
 
     batch_start_time = time.time()
-    router_names = arguments.get("router_names", [])
+    # Dedupe while preserving order: with the connection pool, repeated routers
+    # share one per-router lock and would run serially (and waste worker
+    # threads) instead of in parallel.
+    router_names = list(dict.fromkeys(arguments.get("router_names", [])))
     command = arguments.get("command", "")
     timeout = get_timeout_with_fallback(arguments.get("timeout"))
 

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -5,17 +5,19 @@ Focus: reload must drop pooled connections WITHOUT killing the pool's
 idle-cleanup thread, while shutdown must stop it.
 """
 
+import asyncio
 import sys
 import threading
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
 import jmcp
+from tests.test_device_data import get_device
 
 
 class ConnectionPoolLifecycleTests(unittest.TestCase):
@@ -57,6 +59,77 @@ class ConnectionPoolLifecycleTests(unittest.TestCase):
         self.pool.close_all(shutdown=False)
         fake_device.close.assert_called_once()
         self.assertEqual(self.pool._connections, {})
+
+    def test_close_all_acquires_per_router_lock(self):
+        # Regression: close_all must take each entry's per-router lock before
+        # closing it, so an in-flight operation is waited out rather than having
+        # its live transport closed mid-RPC.
+        fake_device = MagicMock()
+        fake_lock = MagicMock()
+        self.pool._connections["R1"] = {
+            "device": fake_device,
+            "lock": fake_lock,
+            "last_used": 1.0,
+        }
+        self.pool.close_all(shutdown=False)
+        fake_lock.__enter__.assert_called_once()
+        fake_lock.__exit__.assert_called_once()
+        fake_device.close.assert_called_once()
+
+
+class LoadCommitLockLeakTests(unittest.TestCase):
+    """Regression: a failed commit whose rollback/unlock also fail must not
+    leave a still-config-locked session in the pool."""
+
+    def setUp(self):
+        self._orig_devices = jmcp.devices.copy()
+        jmcp.connection_pool.close_all(shutdown=False)
+
+    def tearDown(self):
+        jmcp.devices = self._orig_devices
+        jmcp.connection_pool.close_all(shutdown=False)
+
+    @patch("jmcp.check_config_blocklist", return_value=(False, ""))
+    @patch("jmcp.Config")
+    @patch("jmcp.Device")
+    def test_failed_commit_and_rollback_drops_locked_session(
+        self, mock_device_cls, mock_config_cls, _mock_blocklist
+    ):
+        # Device the pool will hand out.
+        mock_device = MagicMock()
+        mock_device.connected = True
+        mock_device_cls.return_value = mock_device
+
+        # lock() ok, load() ok, diff() truthy, then commit() fails AND the
+        # rollback()/unlock() in the handler's except-block also fail.
+        cfg = MagicMock()
+        cfg.diff.return_value = "+ set system host-name x"
+        cfg.commit.side_effect = RuntimeError("commit failed")
+        cfg.rollback.side_effect = RuntimeError("rollback failed")
+        cfg.unlock.side_effect = RuntimeError("unlock failed")
+        mock_config_cls.return_value = cfg
+
+        jmcp.devices = {"router1": get_device("router1")}
+        ctx = MagicMock()
+        ctx.info = AsyncMock()
+        ctx.warning = AsyncMock()
+        ctx.error = AsyncMock()
+
+        result = asyncio.run(
+            jmcp.handle_load_and_commit_config(
+                {
+                    "router_name": "router1",
+                    "config_text": "set system host-name x",
+                    "config_format": "set",
+                },
+                ctx,
+            )
+        )
+
+        self.assertIn("Failed to load/commit configuration", result[0].text)
+        # The fix: the still-locked session's transport is dropped so the pool
+        # evicts it on next use instead of handing back a locked session.
+        mock_device.close.assert_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -8,6 +8,7 @@ idle-cleanup thread, while shutdown must stop it.
 import asyncio
 import sys
 import threading
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -17,7 +18,7 @@ if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
 import jmcp
-from jnpr.junos.exception import UnlockError
+from jnpr.junos.exception import RpcTimeoutError, UnlockError
 from tests.test_device_data import get_device
 
 
@@ -55,11 +56,15 @@ class ConnectionPoolLifecycleTests(unittest.TestCase):
         self.pool.close_all(shutdown=True)
         self.assertFalse(self.pool._running)
 
-    def test_reload_closes_and_clears_connections(self):
+    def test_reload_closes_connection_but_keeps_entry(self):
+        # close_all closes the device but must NOT remove the entry from
+        # _connections. Clearing would detach an entry an in-flight borrow holds,
+        # orphaning the connection it is about to open. Entry stays, device=None.
         fake_device = self._inject_fake_connection("R1")
         self.pool.close_all(shutdown=False)
         fake_device.close.assert_called_once()
-        self.assertEqual(self.pool._connections, {})
+        self.assertIn("R1", self.pool._connections)
+        self.assertIsNone(self.pool._connections["R1"]["device"])
 
     def test_close_all_acquires_per_router_lock(self):
         # Regression: close_all must take each entry's per-router lock before
@@ -73,9 +78,57 @@ class ConnectionPoolLifecycleTests(unittest.TestCase):
             "last_used": 1.0,
         }
         self.pool.close_all(shutdown=False)
-        fake_lock.__enter__.assert_called_once()
-        fake_lock.__exit__.assert_called_once()
+        fake_lock.acquire.assert_called_once()
+        fake_lock.release.assert_called_once()
         fake_device.close.assert_called_once()
+
+    @patch("jmcp.Device")
+    def test_open_failure_closes_partial_device(self, mock_device_cls):
+        # M3: if Device.open() raises (possibly after partially establishing the
+        # transport), the local device must be closed so it is not leaked.
+        failed_device = MagicMock()
+        failed_device.open.side_effect = RuntimeError("open failed")
+        mock_device_cls.return_value = failed_device
+        orig = jmcp.devices
+        jmcp.devices = {"router1": get_device("router1")}
+        try:
+            with self.assertRaises(RuntimeError):
+                with self.pool.get_connection("router1"):
+                    pass
+        finally:
+            jmcp.devices = orig
+        failed_device.close.assert_called_once()
+        self.assertIsNone(self.pool._connections["router1"]["device"])
+
+    def test_rpc_timeout_evicts_session(self):
+        # R2#2: RpcTimeoutError leaves device.connected True, but the poisoned
+        # session must be evicted (closed + dropped) so it is not reused.
+        dev = MagicMock()
+        dev.connected = True
+        self.pool._connections["router1"] = {
+            "device": dev,
+            "lock": threading.Lock(),
+            "last_used": 1.0,
+        }
+        with self.assertRaises(RpcTimeoutError):
+            with self.pool.get_connection("router1"):
+                raise RpcTimeoutError(dev, None, 1)
+        dev.close.assert_called_once()
+        self.assertIsNone(self.pool._connections["router1"]["device"])
+
+    def test_cleanup_idle_reaps_aged_connection(self):
+        # The idle reaper (previously untested) must close a connection idle past
+        # the timeout and drop the device.
+        dev = MagicMock()
+        dev.connected = True
+        self.pool._connections["router1"] = {
+            "device": dev,
+            "lock": threading.Lock(),
+            "last_used": time.time() - 10_000,  # well past idle_timeout=300
+        }
+        self.pool._cleanup_idle()
+        dev.close.assert_called_once()
+        self.assertIsNone(self.pool._connections["router1"]["device"])
 
     def test_last_used_refreshed_after_failed_operation(self):
         # Regression: a borrow whose operation raises but leaves the device

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -17,6 +17,7 @@ if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
 import jmcp
+from jnpr.junos.exception import UnlockError
 from tests.test_device_data import get_device
 
 
@@ -76,6 +77,26 @@ class ConnectionPoolLifecycleTests(unittest.TestCase):
         fake_lock.__exit__.assert_called_once()
         fake_device.close.assert_called_once()
 
+    def test_last_used_refreshed_after_failed_operation(self):
+        # Regression: a borrow whose operation raises but leaves the device
+        # connected must still refresh last_used, or idle cleanup (which requires
+        # last_used > 0) would never reap that connection.
+        dev = MagicMock()
+        dev.connected = True
+        self.pool._connections["R1"] = {
+            "device": dev,
+            "lock": threading.Lock(),
+            "last_used": 0.0,
+        }
+        try:
+            with self.pool.get_connection("R1"):
+                raise RuntimeError("operation failed mid-RPC")
+        except RuntimeError:
+            pass
+        # device still connected -> not evicted, but last_used must be refreshed
+        self.assertIs(self.pool._connections["R1"]["device"], dev)
+        self.assertGreater(self.pool._connections["R1"]["last_used"], 0)
+
 
 class LoadCommitLockLeakTests(unittest.TestCase):
     """Regression: a failed commit whose rollback/unlock also fail must not
@@ -92,21 +113,27 @@ class LoadCommitLockLeakTests(unittest.TestCase):
     @patch("jmcp.check_config_blocklist", return_value=(False, ""))
     @patch("jmcp.Config")
     @patch("jmcp.Device")
-    def test_failed_commit_and_rollback_drops_locked_session(
+    def test_failed_commit_then_unlock_error_evicts_locked_session(
         self, mock_device_cls, mock_config_cls, _mock_blocklist
     ):
-        # Device the pool will hand out.
+        # Device the pool will hand out. close() drops the session, so the pool
+        # must not reuse it afterwards.
         mock_device = MagicMock()
         mock_device.connected = True
+
+        def _close():
+            mock_device.connected = False
+
+        mock_device.close.side_effect = _close
         mock_device_cls.return_value = mock_device
 
-        # lock() ok, load() ok, diff() truthy, then commit() fails AND the
-        # rollback()/unlock() in the handler's except-block also fail.
+        # lock() ok, load() ok, diff() truthy, commit() fails, and unlock()
+        # raises UnlockError — the REAL failure mode (UnlockError subclasses
+        # RpcError, not any of the previously-allowlisted types).
         cfg = MagicMock()
         cfg.diff.return_value = "+ set system host-name x"
         cfg.commit.side_effect = RuntimeError("commit failed")
-        cfg.rollback.side_effect = RuntimeError("rollback failed")
-        cfg.unlock.side_effect = RuntimeError("unlock failed")
+        cfg.unlock.side_effect = UnlockError(rsp=None)
         mock_config_cls.return_value = cfg
 
         jmcp.devices = {"router1": get_device("router1")}
@@ -127,9 +154,14 @@ class LoadCommitLockLeakTests(unittest.TestCase):
         )
 
         self.assertIn("Failed to load/commit configuration", result[0].text)
-        # The fix: the still-locked session's transport is dropped so the pool
-        # evicts it on next use instead of handing back a locked session.
+        # Cleanup dropped the transport...
         mock_device.close.assert_called()
+        # ...and the pool actually evicts it: the next borrow builds a fresh
+        # Device instead of reusing the locked session.
+        before = mock_device_cls.call_count
+        with jmcp.connection_pool.get_connection("router1"):
+            pass
+        self.assertGreater(mock_device_cls.call_count, before)
 
 
 if __name__ == "__main__":

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Unit tests for the SSH/NETCONF ConnectionPool lifecycle.
+
+Focus: reload must drop pooled connections WITHOUT killing the pool's
+idle-cleanup thread, while shutdown must stop it.
+"""
+
+import sys
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+import jmcp
+
+
+class ConnectionPoolLifecycleTests(unittest.TestCase):
+    def setUp(self):
+        # Explicit idle_timeout so the test is independent of JMCP_POOL_IDLE_TIMEOUT.
+        self.pool = jmcp.ConnectionPool(idle_timeout=300)
+
+    def tearDown(self):
+        # Always stop the background cleanup thread after each test.
+        self.pool.close_all(shutdown=True)
+
+    def _inject_fake_connection(self, name="R1"):
+        fake_device = MagicMock()
+        self.pool._connections[name] = {
+            "device": fake_device,
+            "lock": threading.Lock(),
+            "last_used": 1.0,
+        }
+        return fake_device
+
+    def test_pool_starts_with_running_cleanup_thread(self):
+        self.assertTrue(self.pool._running)
+        self.assertTrue(self.pool._cleanup_thread.is_alive())
+
+    def test_reload_keeps_cleanup_thread_alive(self):
+        # Regression: close_all(shutdown=False) is the reload path. It must NOT
+        # disable the idle-cleanup loop (old code set _running=False here, which
+        # permanently killed the janitor for the rest of the process's life).
+        self.pool.close_all(shutdown=False)
+        self.assertTrue(self.pool._running)
+        self.assertTrue(self.pool._cleanup_thread.is_alive())
+
+    def test_shutdown_stops_cleanup(self):
+        self.pool.close_all(shutdown=True)
+        self.assertFalse(self.pool._running)
+
+    def test_reload_closes_and_clears_connections(self):
+        fake_device = self._inject_fake_connection("R1")
+        self.pool.close_all(shutdown=False)
+        fake_device.close.assert_called_once()
+        self.assertEqual(self.pool._connections, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_junos_pfe.py
+++ b/tests/test_junos_pfe.py
@@ -42,7 +42,8 @@ class JunosPfeHelperTests(unittest.TestCase):
         mock_device = MagicMock()
         mock_rpc = MagicMock()
         mock_rpc.request_pfe_execute.return_value.text = "PFE command output"
-        mock_device.__enter__.return_value = mock_device
+        # The pool yields the Device directly (no `with Device()`), so no
+        # __enter__ wiring is needed.
         mock_device.rpc = mock_rpc
         mock_device_class.return_value = mock_device
 

--- a/tests/test_junos_pfe.py
+++ b/tests/test_junos_pfe.py
@@ -28,9 +28,13 @@ def load_devices(devices_file: str) -> bool:
 class JunosPfeHelperTests(unittest.TestCase):
     def setUp(self):
         self._original_devices = jmcp.devices.copy()
+        # connection_pool is a module-level singleton; drop any connection a
+        # previous test cached so each test gets its own freshly-mocked device.
+        jmcp.connection_pool.close_all(shutdown=False)
 
     def tearDown(self):
         jmcp.devices = self._original_devices
+        jmcp.connection_pool.close_all(shutdown=False)
 
     @patch("jmcp.Device")
     def test_run_junos_pfe_command_success(self, mock_device_class):
@@ -82,7 +86,9 @@ class JunosPfeHelperTests(unittest.TestCase):
     @patch("jmcp.Device")
     def test_run_junos_pfe_command_generic_exception(self, mock_device_class):
         mock_device = MagicMock()
-        mock_device.__enter__.side_effect = Exception("Generic failure")
+        # The pool yields the device directly (no `with Device()`), so simulate a
+        # generic failure on the RPC call itself rather than on __enter__.
+        mock_device.rpc.request_pfe_execute.side_effect = Exception("Generic failure")
         mock_device_class.return_value = mock_device
         devices = {"router1": get_device("router1")}
         jmcp.devices = devices


### PR DESCRIPTION
feat: thread-safe SSH/NETCONF connection pooling

## Summary

Reuse SSH/NETCONF sessions across tool invocations instead of opening
and tearing down a connection per call.

- Thread-safe `ConnectionPool` with per-router locking
- Auto-detection and reconnection of stale sessions
- Background cleanup of idle connections (configurable timeout)
- Graceful shutdown on server exit

## Performance

Tested on 5 Junos routers, 7 commands each (35 operations):

| Mode | Time | Speedup |
|------|------|---------|
| Original | 24.5s | baseline |
| Pooled + sequential | 4.0s | 6.2x |
| Pooled + parallel | 1.2s | 20.7x |

Benchmark methodology and reproduction steps: https://github.com/h-network/junos-mcp-server/tree/h-dev/benchmark

Closes #26
