### PR TITLE
Minimize and security-gate the Junos MCP container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -32,22 +31,27 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: requirements.txt
+          cache-dependency-path: uv.lock
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
-          python -m pip install black pylint nose2 coverage
+          python -m pip install uv==0.12.1
+          uv sync --frozen --no-dev
+          uv pip install --python .venv/bin/python black pylint nose2 coverage
 
       - name: Run Code Quality Tools
         if: matrix.os == 'ubuntu-latest'
         run: |
-          black --check --fast .
-          pylint $(git ls-files '*.py' | grep -vE '^(docs/|build/|tests/|samples/|setup.py|versioneer.py)') --exit-zero
+          .venv/bin/black --check --fast .
+          mapfile -t python_files < <(
+            git ls-files '*.py' |
+              grep -vE '^(docs/|build/|tests/|samples/|setup.py|versioneer.py)'
+          )
+          .venv/bin/pylint "${python_files[@]}" --exit-zero
 
       - name: Run Unit Tests
-        run: python -m unittest discover -s tests -v
+        run: .venv/bin/python -m unittest discover -s tests -v
 
       - name: Upload Test Reports
         if: always()

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,0 +1,88 @@
+name: Container Image
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  TEST_IMAGE: local/junos-mcp-server:test
+
+jobs:
+  validate:
+    name: Validate ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            architecture: amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            architecture: arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.2.0
+
+      - name: Build validation image
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.platform }}
+          load: true
+          tags: ${{ env.TEST_IMAGE }}
+          labels: org.opencontainers.image.source=https://github.com/Juniper/junos-mcp-server
+          cache-from: type=gha,scope=validate-${{ matrix.architecture }}
+          cache-to: type=gha,mode=max,scope=validate-${{ matrix.architecture }}
+
+      - name: Smoke-test Junos MCP runtime
+        run: |
+          docker run --rm --entrypoint sh "${TEST_IMAGE}" -ec '
+            python -c "import jnpr.junos, jxmlease, lxml, mcp, ncclient, paramiko, psutil, serial, starlette, uvicorn"
+            python -m compileall -q /app
+            test -s /app/jmcp.py
+            test "$(id -u)" -ne 0
+          '
+
+      - name: Scan HIGH and CRITICAL vulnerabilities
+        env:
+          TRIVY_SHOW_SUPPRESSED: "true"
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          version: v0.66.0
+          image-ref: ${{ env.TEST_IMAGE }}
+          format: json
+          output: trivy-${{ matrix.architecture }}.json
+          severity: HIGH,CRITICAL
+          exit-code: "0"
+          trivyignores: .trivyignore.yaml
+
+      - name: Upload vulnerability report
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: trivy-junos-mcp-${{ matrix.architecture }}
+          path: trivy-${{ matrix.architecture }}.json
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Enforce CRITICAL vulnerability baseline
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          version: v0.66.0
+          image-ref: ${{ env.TEST_IMAGE }}
+          format: table
+          severity: CRITICAL
+          exit-code: "1"
+          trivyignores: .trivyignore.yaml

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           version: v0.69.3
           image-ref: ${{ env.TEST_IMAGE }}
+          scanners: vuln
           format: json
           output: trivy-${{ matrix.architecture }}.json
           severity: HIGH,CRITICAL
@@ -85,6 +86,7 @@ jobs:
           version: v0.69.3
           skip-setup-trivy: true
           image-ref: ${{ env.TEST_IMAGE }}
+          scanners: vuln
           format: table
           severity: CRITICAL
           exit-code: "1"

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -53,6 +53,8 @@ jobs:
             python -m compileall -q /app
             test -s /app/jmcp.py
             test "$(id -u)" -ne 0
+            command -v ssh
+            ssh -V
           '
 
       - name: Scan HIGH and CRITICAL vulnerabilities

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -58,9 +58,9 @@ jobs:
       - name: Scan HIGH and CRITICAL vulnerabilities
         env:
           TRIVY_SHOW_SUPPRESSED: "true"
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
-          version: v0.66.0
+          version: v0.69.3
           image-ref: ${{ env.TEST_IMAGE }}
           format: json
           output: trivy-${{ matrix.architecture }}.json
@@ -78,9 +78,10 @@ jobs:
           retention-days: 14
 
       - name: Enforce CRITICAL vulnerability baseline
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
-          version: v0.66.0
+          version: v0.69.3
+          skip-setup-trivy: true
           image-ref: ${{ env.TEST_IMAGE }}
           format: table
           severity: CRITICAL

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,1 @@
+vulnerabilities: []

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV LOG_LEVEL=INFO
 ENV FASTMCP_HOST=0.0.0.0
 ENV PATH="/app/.venv/bin:$PATH"
 
-RUN apk add --no-cache libffi libgcc libstdc++ libxml2 libxslt openssl \
+RUN apk add --no-cache libffi libgcc libstdc++ libxml2 libxslt openssh-client openssl \
  && addgroup -S jmcp \
  && adduser -S -G jmcp -s /bin/sh jmcp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,22 @@
-# Use Python 3.11 slim image as base
-FROM python:3.11-slim
+FROM python:3.11-alpine3.23 AS builder
 
-# Set metadata
-LABEL maintainer="Nilesh Simaria"
-LABEL description="Junos MCP Server"
-LABEL version="1.1.0"
+RUN apk add --no-cache \
+    build-base cargo libffi-dev libxml2-dev libxslt-dev openssl-dev
 
-# Set environment variables
+WORKDIR /app
+COPY pyproject.toml uv.lock ./
+COPY jmcp.py jmcp_token_manager.py ./
+COPY utils/ ./utils/
+COPY block.cmd block.cfg ./
+
+RUN python -m venv /opt/uv \
+ && /opt/uv/bin/pip install --no-cache-dir uv==0.12.1 \
+ && /opt/uv/bin/uv sync --frozen --no-dev --no-install-project \
+ && /app/.venv/bin/python -c \
+      "import jnpr.junos, jxmlease, lxml, mcp, ncclient, paramiko, psutil, serial, starlette, uvicorn"
+
+FROM python:3.11-alpine3.23
+
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV MCP_SERVER_HOST=0.0.0.0
@@ -15,56 +25,32 @@ ENV MCP_TRANSPORT=stdio
 ENV DEVICE_CONFIG=/app/config/devices.json
 ENV LOG_LEVEL=INFO
 ENV FASTMCP_HOST=0.0.0.0
+ENV PATH="/app/.venv/bin:$PATH"
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
-    openssh-client \
-    net-tools \
-    iputils-ping \
-    traceroute \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache libffi libgcc libstdc++ libxml2 libxslt openssl \
+ && addgroup -S jmcp \
+ && adduser -S -G jmcp -s /bin/sh jmcp
 
-# Create application directory
 WORKDIR /app
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/jmcp.py /app/jmcp_token_manager.py ./
+COPY --from=builder /app/utils/ ./utils/
+COPY --from=builder /app/block.cmd /app/block.cfg ./
 
-# Create directories for configuration and logs
-RUN mkdir -p /app/config /app/logs /app/backups
+RUN mkdir -p /app/config /app/logs /app/backups \
+ && chown -R jmcp:jmcp /app \
+ && chmod 755 /app/jmcp.py
 
-# Copy requirements file first (for better Docker layer caching)
-COPY requirements.txt .
-
-# Install Python dependencies
-RUN pip install --no-cache-dir -r requirements.txt
-
-# Copy the main application and utils module
-COPY jmcp.py .
-COPY jmcp_token_manager.py .
-COPY utils/ ./utils/
-COPY block.cmd .
-COPY block.cfg .
-
-# Copy test files
-COPY tests/ ./tests/
-
-# Copy configuration files
-# COPY devices.json /app/config/devices.json
-
-# Create a non-root user for security
-RUN groupadd -r jmcp && useradd -r -g jmcp -s /bin/bash jmcp
-
-# Set ownership and permissions
-RUN chown -R jmcp:jmcp /app
-RUN chmod +x jmcp.py
-
-# Switch to non-root user
 USER jmcp
 
-# Expose the default port (though stdio transport doesn't need it)
+LABEL maintainer="Nilesh Simaria"
+LABEL description="Junos MCP Server"
+LABEL version="1.1.0"
+LABEL org.opencontainers.image.source="https://github.com/Juniper/junos-mcp-server"
+
 EXPOSE 30030
 
-# Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import psutil; exit(0 if psutil.Process().is_running() else 1)"
+    CMD python -c "import psutil; raise SystemExit(0 if psutil.Process().is_running() else 1)"
 
-# Default command
 CMD ["python", "jmcp.py", "-f", "/app/config/devices.json", "-t", "stdio"]


### PR DESCRIPTION
## Summary

- replaces the tools-heavy Debian image with a non-root, multi-stage Python 3.11 Alpine runtime
- installs exactly the existing uv.lock in frozen mode and removes unused ping, traceroute, and general networking utilities while retaining SSH for PyEZ ProxyCommand operation
- preserves PyEZ/ncclient, health checks, stdio transport, configuration, and the NITA integration contract
- adds native amd64/arm64 builds, smoke tests, complete Trivy reporting, and a blocking unaccepted-CRITICAL gate in the source repository

Cross-repository design authority:
https://github.com/tbelz/nita/tree/codex/container-security-baseline/openspec/changes/archive/2026-08-05-enforce-container-security-baseline

Tracks Juniper/nita#75. The supported boundary remains a locally operated trusted lab, not an internet-facing or multi-tenant deployment.

## Validation

- frozen uv sync, Python compile checks, and 52 unit tests
- native ARM non-root runtime, import, health, and SSH smoke tests
- native amd64 and arm64 fork jobs
- Trivy 0.69.3: 18 HIGH records and 0 CRITICAL records
- actionlint and YAML validation